### PR TITLE
Updated 9e Score Sheet Object Locked Tag

### DIFF
--- a/9e/TTSJSON/2121424734.json
+++ b/9e/TTSJSON/2121424734.json
@@ -36490,7 +36490,7 @@
         "b": 1.0
       },
       "LayoutGroupSortIndex": 0,
-      "Locked": false,
+      "Locked": true,
       "Grid": true,
       "Snap": true,
       "IgnoreFoW": false,


### PR DESCRIPTION
Updated the TTS json for the 9e Score Sheet object from Locked: false to Locked: true.